### PR TITLE
Add notes about stack frame traversal for CSE 100 materials

### DIFF
--- a/Course-Specific/CSE 100/GDB Cheatsheet.md
+++ b/Course-Specific/CSE 100/GDB Cheatsheet.md
@@ -1,4 +1,5 @@
-Originally written by [Sravya Balasa](https://www.linkedin.com/in/sravyabalasa/)
+Originally written by [Sravya Balasa](https://www.linkedin.com/in/sravyabalasa/)\
+Additions made by [Aatash Pestonjamasp](https://www.linkedin.com/in/aatash-pestonjamasp)
 
 # Q: What is GDB?
 **GDB** is the **G**NU **D**e**b**ugger, a portable system that runs on many Unix-like systems. It is especially useful when debugging C/C++ programs, such as in CSE 100!
@@ -66,11 +67,39 @@ Oh no! Your program segfaulted ): GDB has a command `backtrace` which prints out
 
 This is especially useful to see which functions/lines your program went through before failure.
 
+## Frame
+`frame i`
+
+Allows you to travel directly to function stack frame `i` (ex. travel to `frame 2`).
+This is especially useful if you have a seg fault and want to print out values
+from your code's stack frame!
+
 ## Up
 `up`
 
 Travel up the function call stack by a single stack frame (i.e. a single function 
-call)
+call). Useful if you have a seg fault and see an unfamiliar line of code, as you
+can use it to travel up to your code.
+
+There are also other variations including:
+* `up i`
+
+This allows you to travel up a variable `i` number of stack frames (ex. `up 2` 
+stack frames).
+
+## Down
+`down`
+
+Travel down the function call stack by a single stack frame (i.e. a single function 
+call). Useful if you wish to check the values of other function calls/ frames at 
+any given point.
+
+There are also other variations including:
+* `down i`
+
+This allows you to travel down a variable `i` number of stack frames (ex. `down 2` 
+stack frames).
+
 
 
 # Notes

--- a/Course-Specific/CSE 100/GDB Cheatsheet.md
+++ b/Course-Specific/CSE 100/GDB Cheatsheet.md
@@ -66,6 +66,13 @@ Oh no! Your program segfaulted ): GDB has a command `backtrace` which prints out
 
 This is especially useful to see which functions/lines your program went through before failure.
 
+## Up
+`up`
+
+Travel up the function call stack by a single stack frame (i.e. a single function 
+call)
+
+
 # Notes
 * `Ctrl-d` or `quit` exits the program
 * GDB remembers the last command you executed, so you can repeatedly press `Enter` if you're executing the same command over and over.

--- a/Course-Specific/CSE 100/Got a Seg Fault.md
+++ b/Course-Specific/CSE 100/Got a Seg Fault.md
@@ -33,7 +33,8 @@ $ gdb someProgram
 (gdb) run arg1 arg2
 ```
 
-This will then give you a line number where the issue is, or tell you what's going on. 
+This will then give you a line number where the issue is, or tell you what's going on.  
+If you don't see anything, run `bt` (or `backtrace`) to view the entire call stack.
 
 ## Unfamiliar Code
 

--- a/Course-Specific/CSE 100/Got a Seg Fault.md
+++ b/Course-Specific/CSE 100/Got a Seg Fault.md
@@ -1,4 +1,5 @@
-Originally written by [Ronak Shah](https://ronakshah.org/)
+Originally written by [Ronak Shah](https://ronakshah.org/)\
+Additions made by [Aatash Pestonjamasp](https://www.linkedin.com/in/aatash-pestonjamasp)
 
 # Got a Seg Fault?
 In your C/C++ programming endeavors, you'll often see a scary error message from time to time:
@@ -32,6 +33,32 @@ $ gdb someProgram
 (gdb) run arg1 arg2
 ```
 
-This will then give you a line number where the issue is, or tell you what's going on. If you don't see anything, run `bt` (or `backtrace`) to view the entire call stack.
+This will then give you a line number where the issue is, or tell you what's going on. 
+
+Once you encounter the seg fault after running, you may encounter an unfamiliar 
+line of code, such as below:
+
+```
+Program received signal SIGSEGV, Segmentation fault.
+0x00005586d963f990 in std::_Hashtable<char, std::pair<char const, TestSet::Node*>, std::allocator<std::pair<char const, TestSet::Node*> >, std::__detail::_Select1st, std::equal_to<char>, std::hash<char>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::size (this=0x8)
+    at /usr/include/c++/12/bits/hashtable.h:649
+649           { return _M_element_count; }
+```
+
+Fear not! Your code simply may have made a system call incorrectly where the 
+actual segmentation fault occurred. You will need to investigate what in your code
+caused a system or other function call to be made incorrectly.
+
+At this point, you may want to look into your code, by printing values, etc, but
+may find that your variables are out of scope; gdb has taken you to the "deeper
+level" system calls. To travel to your function's scope, you can run `bt` (or `backtrace`)  
+to view the entire call stack. You will see  numbers next to each function indicating 
+the level of the stack it was made from. 
+
+Once you find the number corresponding to your code, you can type `up` to move 
+back up the function call stack until you reach your code, and `down` if you 
+want to move to lower levels at any point. You may also type `frame` followed by 
+the stack frame number (for example `frame 3`) to select the stack frame of the function designated with #3 by `backtrace`). From there, you can commence your debugging!
+
 
 More help on GDB — Check out the [GDB Cheatsheet](GDB%20Cheatsheet.md)!

--- a/Course-Specific/CSE 100/Got a Seg Fault.md
+++ b/Course-Specific/CSE 100/Got a Seg Fault.md
@@ -35,8 +35,10 @@ $ gdb someProgram
 
 This will then give you a line number where the issue is, or tell you what's going on. 
 
+## Unfamiliar Code
+
 Once you encounter the seg fault after running, you may encounter an unfamiliar 
-line of code, such as below:
+line of code, an example of which is shown below:
 
 ```
 Program received signal SIGSEGV, Segmentation fault.
@@ -49,7 +51,7 @@ Fear not! Your code simply may have made a system call incorrectly where the
 actual segmentation fault occurred. You will need to investigate what in your code
 caused a system or other function call to be made incorrectly.
 
-At this point, you may want to look into your code, by printing values, etc, but
+At this point, you will want to look into your code, by printing values, etc, but
 may find that your variables are out of scope; gdb has taken you to the "deeper
 level" system calls. To travel to your function's scope, you can run `bt` (or `backtrace`)  
 to view the entire call stack. You will see  numbers next to each function indicating 


### PR DESCRIPTION
Added notes about traversing the stack frame via `up`, `down`, `frame` in CSE 100 `GDB Cheatsheet.md` and additional workflow to `Got a Seg Fault.md`.